### PR TITLE
更新协议以适配bubbler v1.2.1

### DIFF
--- a/examples/bubbler/core/excontrol.bb
+++ b/examples/bubbler/core/excontrol.bb
@@ -5,7 +5,7 @@ struct RovExcontrolClampData[6] {
     int16 wrist[2] [order = "big"] {
         get percent(float64): value / 3000.0 * 100.0;
         get percent_int(int32): (int32)(value / 3000.0 * 100.0);
-        set percent(float64): value > -0.5 && value < 0.5 ? 0 : value;
+        set percent(float64): value > -0.5 && value < 0.5 ? (float64)0 : value;
     };
     void [2];
 }

--- a/examples/bubbler/core/sensor.bb
+++ b/examples/bubbler/core/sensor.bb
@@ -22,7 +22,7 @@ struct RovSensorWaterTempDepthPressData[6] {
     };
     uint16 depth[2] [order = "big"] {
         get trustable(bool): (value / 100.0) < 1.0 ? false : true;
-        get confidence(int32): (value / 100.0) < 1.0 ? 0 : 100;
+        get confidence(int32): (value / 100.0) < 1.0 ? (int32)0 : (int32)100;
         get depth_display(float64): value / 100.0;
         set depth_display(float64): (uint16)(value * 100.0);
     };

--- a/examples/bubbler/core/types.bb
+++ b/examples/bubbler/core/types.bb
@@ -68,7 +68,7 @@ struct RovlinkFrame[8] {
 }
 
 struct RovlinkStdFrame[10] {
-    uint8 magic[1];
+    uint8 magic[1] = 0xFD;
     RovlinkFrame;
     uint8 crc[1];
 }


### PR DESCRIPTION
啵啵v1.2.0起支持Go语言，要求三元运算符的分支强制指明类型，故此更改